### PR TITLE
Add minimal self experiment tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Self-Experiment Tracker
+
+Simple Streamlit app with SQLite storage for logging self experiments.
+
+## Usage
+
+```
+pip install -r requirements.txt
+streamlit run app.py
+```

--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from matplotlib import pyplot as plt
+from typing import Optional
+
+import db
+
+
+def load_dataframe(tag: Optional[str] = None, intervention: Optional[str] = None):
+    rows = db.fetch_entries(tag=tag, intervention=intervention)
+    df = pd.DataFrame(rows, columns=[
+        'id', 'date', 'intervention', 'dose', 'mood', 'focus', 'sleep_quality',
+        'heart_rate', 'sleep_hours', 'notes', 'tags'
+    ])
+    if not df.empty:
+        df['date'] = pd.to_datetime(df['date'])
+    return df
+
+
+def plot_trend(metric: str, tag: Optional[str] = None, intervention: Optional[str] = None):
+    df = load_dataframe(tag, intervention)
+    if df.empty or metric not in df:
+        return None
+    df = df.sort_values('date')
+    ax = df.plot(x='date', y=metric, marker='o', legend=False)
+    ax.set_ylabel(metric)
+    fig = ax.get_figure()
+    return fig
+
+
+def export_csv(path: str, tag: Optional[str] = None, intervention: Optional[str] = None):
+    df = load_dataframe(tag, intervention)
+    df.to_csv(path, index=False)
+
+
+if __name__ == "__main__":
+    db.init_db()
+    df = load_dataframe()
+    print(df.head())

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+import streamlit as st
+from datetime import date
+import pandas as pd
+import db
+import analysis
+
+
+def main():
+    conn = db.get_conn()
+    db.init_db(conn)
+    st.title("Self-Experiment Tracker")
+
+    with st.form("entry_form", clear_on_submit=True):
+        st.subheader("New Entry")
+        date_value = st.date_input("Date", value=date.today())
+        intervention = st.text_input("Intervention")
+        dose = st.text_input("Dose / Intensity")
+        mood = st.slider("Mood", 1, 10, 5)
+        focus = st.slider("Focus", 1, 10, 5)
+        sleep_quality = st.slider("Sleep Quality", 1, 10, 5)
+        heart_rate = st.number_input("Heart Rate", step=1.0, format="%0.1f")
+        sleep_hours = st.number_input("Sleep Hours", step=0.5)
+        notes = st.text_area("Notes")
+        tags_text = st.text_input("Tags (comma separated)")
+        submitted = st.form_submit_button("Add")
+        if submitted:
+            tags = [t.strip() for t in tags_text.split(',') if t.strip()]
+            db.add_entry(
+                intervention=intervention,
+                dose=dose,
+                date_value=date_value,
+                mood=mood,
+                focus=focus,
+                sleep_quality=sleep_quality,
+                heart_rate=heart_rate,
+                sleep_hours=sleep_hours,
+                notes=notes,
+                tags=tags,
+                conn=conn,
+            )
+            st.success("Added entry")
+
+    st.subheader("Entries")
+    df = analysis.load_dataframe()
+    if not df.empty:
+        unique_tags = sorted({t for sub in df['tags'].dropna() for t in str(sub).split(',') if t})
+        tag_filter = st.multiselect("Filter by tag", unique_tags)
+        intervention_filter = st.text_input("Filter by intervention")
+        filtered = df
+        if tag_filter:
+            filtered = filtered[filtered['tags'].apply(lambda x: any(tag in str(x) for tag in tag_filter))]
+        if intervention_filter:
+            filtered = filtered[filtered['intervention'].str.contains(intervention_filter, case=False)]
+        st.dataframe(filtered.sort_values('date', ascending=False))
+
+        metric = st.selectbox("Plot metric", ['mood', 'focus', 'sleep_quality'])
+        fig = analysis.plot_trend(metric, None, None)
+        if fig:
+            st.pyplot(fig)
+    else:
+        st.write("No entries yet.")
+
+    if st.button("Export CSV"):
+        analysis.export_csv("export.csv")
+        with open("export.csv", "rb") as f:
+            st.download_button(label="Download", data=f, file_name="entries.csv", mime="text/csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,96 @@
+import sqlite3
+from datetime import date
+from typing import Iterable, Optional, List
+
+DB_PATH = 'experiments.db'
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    date TEXT NOT NULL,
+    intervention TEXT NOT NULL,
+    dose TEXT,
+    mood INTEGER,
+    focus INTEGER,
+    sleep_quality INTEGER,
+    heart_rate REAL,
+    sleep_hours REAL,
+    notes TEXT,
+    tags TEXT
+);
+"""
+
+def get_conn(path: str = DB_PATH):
+    conn = sqlite3.connect(path, check_same_thread=False)
+    return conn
+
+def init_db(conn=None):
+    if conn is None:
+        conn = get_conn()
+    conn.execute(SCHEMA)
+    conn.commit()
+
+
+def add_entry(
+    intervention: str,
+    dose: str,
+    date_value: Optional[date] = None,
+    mood: Optional[int] = None,
+    focus: Optional[int] = None,
+    sleep_quality: Optional[int] = None,
+    heart_rate: Optional[float] = None,
+    sleep_hours: Optional[float] = None,
+    notes: str = "",
+    tags: Optional[Iterable[str]] = None,
+    conn=None,
+):
+    if conn is None:
+        conn = get_conn()
+    if date_value is None:
+        date_value = date.today()
+    tags_text = ",".join(tags) if tags else ""
+    conn.execute(
+        "INSERT INTO entries (date, intervention, dose, mood, focus, sleep_quality, heart_rate, sleep_hours, notes, tags)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            date_value.isoformat(),
+            intervention,
+            dose,
+            mood,
+            focus,
+            sleep_quality,
+            heart_rate,
+            sleep_hours,
+            notes,
+            tags_text,
+        ),
+    )
+    conn.commit()
+
+
+def fetch_entries(
+    tag: Optional[str] = None,
+    intervention: Optional[str] = None,
+    conn=None,
+):
+    if conn is None:
+        conn = get_conn()
+    query = "SELECT * FROM entries"
+    params: List[str] = []
+    clauses = []
+    if tag:
+        clauses.append("tags LIKE ?")
+        params.append(f"%{tag}%")
+    if intervention:
+        clauses.append("intervention = ?")
+        params.append(intervention)
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    query += " ORDER BY date DESC"
+    cur = conn.execute(query, params)
+    rows = cur.fetchall()
+    return rows
+
+
+if __name__ == "__main__":
+    init_db()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+matplotlib


### PR DESCRIPTION
## Summary
- add a small Streamlit app for logging daily experiments with SQLite
- support CSV export and basic trend plots
- include helper modules for DB and analysis

## Testing
- `python3 -m py_compile db.py analysis.py app.py`
- `pip install -r requirements.txt`
- `streamlit run app.py --server.headless true --server.port 8501` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_684758cc81b8832cb6855f644a5ca7bf